### PR TITLE
Implement processing pipeline with clustering and scoring

### DIFF
--- a/src/services/processing-service.js
+++ b/src/services/processing-service.js
@@ -1,0 +1,29 @@
+const DataCleaningService = require('./data-cleaning-service');
+const DeduplicationService = require('./deduplication-service');
+const { ClusteringService } = require('./clustering-service');
+const { PriorityScoringService } = require('./priority-scoring-service');
+
+class ProcessingService {
+  constructor(config = {}) {
+    this.cleaner = new DataCleaningService();
+    this.deduper = new DeduplicationService();
+    this.clusterer = new ClusteringService(config.clustering || {});
+    this.scorer = new PriorityScoringService(config.scoring || {});
+  }
+
+  async run(rawKeywords, options = {}) {
+    const cleaned = await this.cleaner.cleanKeywords(rawKeywords, options.cleaning);
+    const { unique } = await this.deduper.deduplicateKeywords(cleaned, options.deduplication);
+    const clusters = await this.clusterer.performAdvancedClustering(unique, options.clustering);
+    clusters.forEach((cluster, cid) => {
+      cluster.keywords.forEach(k => {
+        k.cluster_id = cid;
+        k.cluster_name = cluster.name;
+      });
+    });
+    const scored = await this.scorer.calculatePriorityScores(unique, clusters, options.scoring);
+    return { keywords: scored, clusters };
+  }
+}
+
+module.exports = ProcessingService;

--- a/test/processing-service.test.js
+++ b/test/processing-service.test.js
@@ -1,0 +1,18 @@
+const ProcessingService = require('../src/services/processing-service');
+
+describe('ProcessingService', () => {
+  test('runs full pipeline and scores keywords', async () => {
+    const service = new ProcessingService();
+    const rawKeywords = [
+      { keyword: 'apple pie recipe', search_volume: 1000, competition: 0.2 },
+      { keyword: 'banana bread recipe', search_volume: 800, competition: 0.25 },
+      { keyword: 'buy used car', search_volume: 900, competition: 0.4 },
+      { keyword: 'car dealer near me', search_volume: 700, competition: 0.35 }
+    ];
+
+    const result = await service.run(rawKeywords, { clustering: { clusterCount: 2 } });
+
+    expect(result.clusters.length).toBe(2);
+    expect(result.keywords.every(k => k.priority_score !== undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add ProcessingService to run full pipeline (clean, dedupe, cluster, score)
- integrate pipeline with existing ProcessCommand
- test ProcessingService

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_688874a9dcd883339501e3b61f513adf